### PR TITLE
fix: highlight generic Set types

### DIFF
--- a/src/tokenizeTypeScript.js
+++ b/src/tokenizeTypeScript.js
@@ -56,6 +56,7 @@ const State = {
   BeforeArrowFunctionParameters: 53,
   AfterKeywordPropertyTypeOf: 54,
   AfterPropertyTypeQuery: 55,
+  AfterNewExpressionCallee: 56,
 }
 
 /**
@@ -788,6 +789,42 @@ export const tokenizeLine = (line, lineState) => {
         } else if ((next = part.match(RE_VERTICAL_LINE))) {
           token = TokenType.Punctuation
           state = State.InsideTypeExpression
+        } else {
+          throw new Error('no')
+        }
+        break
+      case State.InsideGeneric:
+        if ((next = part.match(RE_ANGLE_OPEN))) {
+          stack.push(state)
+          token = TokenType.Punctuation
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_ANGLE_CLOSE))) {
+          token = TokenType.Punctuation
+          state = stack.pop() || State.TopLevelContent
+        } else if ((next = part.match(RE_BUILTIN_CLASS))) {
+          token = TokenType.Class
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_TYPE_PRIMITIVE))) {
+          token = TokenType.TypePrimitive
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_VARIABLE_NAME))) {
+          token = TokenType.Type
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_WHITESPACE))) {
+          token = TokenType.Whitespace
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_PUNCTUATION))) {
+          token = TokenType.Punctuation
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_VERTICAL_LINE))) {
+          token = TokenType.Punctuation
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_AMPERSAND))) {
+          token = TokenType.Punctuation
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_QUESTION_MARK))) {
+          token = TokenType.Punctuation
+          state = State.InsideGeneric
         } else {
           throw new Error('no')
         }
@@ -1908,7 +1945,7 @@ export const tokenizeLine = (line, lineState) => {
           state = State.AfterKeywordNew
         } else if ((next = part.match(RE_VARIABLE_NAME))) {
           token = TokenType.Class
-          state = State.TopLevelContent
+          state = State.AfterNewExpressionCallee
         } else if ((next = part.match(RE_ROUND_OPEN))) {
           token = TokenType.Punctuation
           state = State.TopLevelContent
@@ -1922,6 +1959,28 @@ export const tokenizeLine = (line, lineState) => {
           stack.push(state)
           token = TokenType.Comment
           state = State.InsideBlockComment
+        } else {
+          throw new Error('no')
+        }
+        break
+      case State.AfterNewExpressionCallee:
+        if ((next = part.match(RE_WHITESPACE))) {
+          token = TokenType.Whitespace
+          state = State.AfterNewExpressionCallee
+        } else if ((next = part.match(RE_ANGLE_OPEN))) {
+          stack.push(State.TopLevelContent)
+          token = TokenType.Punctuation
+          state = State.InsideGeneric
+        } else if ((next = part.match(RE_DOT))) {
+          token = TokenType.Punctuation
+          state = State.AfterPropertyDot
+        } else if ((next = part.match(RE_BLOCK_COMMENT_START))) {
+          stack.push(state)
+          token = TokenType.Comment
+          state = State.InsideBlockComment
+        } else if ((next = part.match(RE_PUNCTUATION))) {
+          token = TokenType.Punctuation
+          state = State.TopLevelContent
         } else {
           throw new Error('no')
         }

--- a/src/tokenizeTypeScript.js
+++ b/src/tokenizeTypeScript.js
@@ -56,7 +56,7 @@ const State = {
   BeforeArrowFunctionParameters: 53,
   AfterKeywordPropertyTypeOf: 54,
   AfterPropertyTypeQuery: 55,
-  AfterNewExpressionCallee: 56,
+  AfterGenericSetCallee: 56,
 }
 
 /**
@@ -226,6 +226,7 @@ const RE_SHEBANG = /^\#\!\/.*/
 const RE_SPREAD = /^\.\.\./
 const RE_BUILTIN_CLASS =
   /^(?:Array|Object|Promise|ArrayBuffer|URL|URLSearchParams|WebSocket|FileSystemHandle|Function|StorageEvent|MessageEvent|MessageChannel|Int32Array|Boolean|String|Error|Set|RegExp|Map|WeakMap|RangeError|Date|Headers|Response|Request|Buffer|MessagePort|FileHandle|X509Certificate|Blob|HTMLElement|MutationRecord|HTMLVideoElement)\b/
+const RE_SET = /^Set\b/
 
 const RE_KEYWORD_NEW = /^new\b/
 const RE_KEYWORD_IMPLEMENTS = /^implements\b/
@@ -1943,9 +1944,12 @@ export const tokenizeLine = (line, lineState) => {
         } else if ((next = part.match(RE_KEYWORD_NEW))) {
           token = TokenType.KeywordNew
           state = State.AfterKeywordNew
+        } else if ((next = part.match(RE_SET))) {
+          token = TokenType.Class
+          state = State.AfterGenericSetCallee
         } else if ((next = part.match(RE_VARIABLE_NAME))) {
           token = TokenType.Class
-          state = State.AfterNewExpressionCallee
+          state = State.TopLevelContent
         } else if ((next = part.match(RE_ROUND_OPEN))) {
           token = TokenType.Punctuation
           state = State.TopLevelContent
@@ -1963,10 +1967,10 @@ export const tokenizeLine = (line, lineState) => {
           throw new Error('no')
         }
         break
-      case State.AfterNewExpressionCallee:
+      case State.AfterGenericSetCallee:
         if ((next = part.match(RE_WHITESPACE))) {
           token = TokenType.Whitespace
-          state = State.AfterNewExpressionCallee
+          state = State.AfterGenericSetCallee
         } else if ((next = part.match(RE_ANGLE_OPEN))) {
           stack.push(State.TopLevelContent)
           token = TokenType.Punctuation

--- a/test/baselines/generic-set.txt
+++ b/test/baselines/generic-set.txt
@@ -8,8 +8,8 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-Class
+Type
 Punctuation
 Punctuation
 Punctuation
-Punctuation
+NewLine

--- a/test/baselines/rollup-build-plugins-generate-license-file.txt
+++ b/test/baselines/rollup-build-plugins-generate-license-file.txt
@@ -137,7 +137,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation
@@ -314,7 +314,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-docs-repl-stores-rollupoutput.txt
+++ b/test/baselines/rollup-docs-repl-stores-rollupoutput.txt
@@ -611,7 +611,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-nodes-importexpression.txt
+++ b/test/baselines/rollup-src-ast-nodes-importexpression.txt
@@ -493,7 +493,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-nodes-labeledstatement.txt
+++ b/test/baselines/rollup-src-ast-nodes-labeledstatement.txt
@@ -240,7 +240,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation
@@ -459,7 +459,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-nodes-shared-callexpressionbase.txt
+++ b/test/baselines/rollup-src-ast-nodes-shared-callexpressionbase.txt
@@ -251,7 +251,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-nodes-shared-objectentity.txt
+++ b/test/baselines/rollup-src-ast-nodes-shared-objectentity.txt
@@ -541,7 +541,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-scopes-childscope.txt
+++ b/test/baselines/rollup-src-ast-scopes-childscope.txt
@@ -830,7 +830,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-utils-pathtracker.txt
+++ b/test/baselines/rollup-src-ast-utils-pathtracker.txt
@@ -404,7 +404,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -692,7 +692,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-variables-exportdefaultvariable.txt
+++ b/test/baselines/rollup-src-ast-variables-exportdefaultvariable.txt
@@ -929,7 +929,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-ast-variables-parametervariable.txt
+++ b/test/baselines/rollup-src-ast-variables-parametervariable.txt
@@ -328,7 +328,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -360,7 +360,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -409,7 +409,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -456,7 +456,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-bundle.txt
+++ b/test/baselines/rollup-src-bundle.txt
@@ -409,7 +409,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-externalmodule.txt
+++ b/test/baselines/rollup-src-externalmodule.txt
@@ -937,7 +937,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-finalisers-shared-getinteropblock.txt
+++ b/test/baselines/rollup-src-finalisers-shared-getinteropblock.txt
@@ -190,7 +190,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-graph.txt
+++ b/test/baselines/rollup-src-graph.txt
@@ -626,7 +626,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-moduleloader.txt
+++ b/test/baselines/rollup-src-moduleloader.txt
@@ -705,7 +705,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -797,7 +797,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-executionorder.txt
+++ b/test/baselines/rollup-src-utils-executionorder.txt
@@ -224,11 +224,11 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Whitespace
 Punctuation
 Whitespace
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -245,7 +245,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-fileemitter.txt
+++ b/test/baselines/rollup-src-utils-fileemitter.txt
@@ -1038,7 +1038,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-getorcreate.txt
+++ b/test/baselines/rollup-src-utils-getorcreate.txt
@@ -137,7 +137,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-getstaticdependencies.txt
+++ b/test/baselines/rollup-src-utils-getstaticdependencies.txt
@@ -135,7 +135,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -271,11 +271,11 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Whitespace
 Punctuation
 Whitespace
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-outputbundle.txt
+++ b/test/baselines/rollup-src-utils-outputbundle.txt
@@ -144,7 +144,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation
@@ -392,7 +392,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-plugindriver.txt
+++ b/test/baselines/rollup-src-utils-plugindriver.txt
@@ -616,7 +616,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+Type
 Punctuation
 Punctuation
 Punctuation
@@ -877,7 +877,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-renderchunks.txt
+++ b/test/baselines/rollup-src-utils-renderchunks.txt
@@ -1796,7 +1796,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation
@@ -2474,7 +2474,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-utils-traversestaticdependencies.txt
+++ b/test/baselines/rollup-src-utils-traversestaticdependencies.txt
@@ -73,7 +73,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/rollup-src-watch-watch.txt
+++ b/test/baselines/rollup-src-watch-watch.txt
@@ -1435,7 +1435,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/baselines/typescript-Issue157.txt
+++ b/test/baselines/typescript-Issue157.txt
@@ -8,7 +8,7 @@ KeywordNew
 Whitespace
 Class
 Punctuation
-VariableName
+TypePrimitive
 Punctuation
 Punctuation
 Punctuation

--- a/test/cases/generic-set.ts
+++ b/test/cases/generic-set.ts
@@ -1,1 +1,1 @@
-const instances = new Set<Object>();
+const instances = new Set<ActiveTodoViewInstance>()


### PR DESCRIPTION
Highlight project-defined generic arguments in constructor calls such as Set<ActiveTodoViewInstance> as Type tokens. Updates the generic Set regression fixture so built-in types no longer mask this case.