### PR TITLE
fix: highlight readonly array assertion types

### DIFF
--- a/src/tokenizeTypeScript.js
+++ b/src/tokenizeTypeScript.js
@@ -232,6 +232,7 @@ const RE_KEYWORD_EXTENDS = /^extends\b/
 const RE_KEYWORD_READONLY = /^readonly\b/
 const RE_KEYWORD_ASYNC = /^async\b/
 const RE_KEYWORD_AS = /^as\b/
+const RE_READONLY_TYPE_ASSERTION = /^as\s+readonly\b/
 const RE_KEYWORD_FROM = /^from\b/
 const RE_KEYWORD_GLOBAL = /^global\b/
 const RE_SHEBANG = /^\#\!\/.*/
@@ -450,6 +451,11 @@ export const tokenizeLine = (line, lineState) => {
               state = State.TopLevelContent
               break
             case 'as':
+              token = TokenType.KeywordControl
+              state = RE_READONLY_TYPE_ASSERTION.test(part)
+                ? State.BeforeType
+                : State.TopLevelContent
+              break
             case 'break':
             case 'case':
             case 'catch':
@@ -1082,6 +1088,11 @@ export const tokenizeLine = (line, lineState) => {
               state = State.TopLevelContent
               break
             case 'as':
+              token = TokenType.KeywordControl
+              state = RE_READONLY_TYPE_ASSERTION.test(part)
+                ? State.BeforeType
+                : State.TopLevelContent
+              break
             case 'break':
             case 'case':
             case 'catch':

--- a/test/baselines/type-assertion-readonly-array.txt
+++ b/test/baselines/type-assertion-readonly-array.txt
@@ -1,0 +1,16 @@
+Keyword
+Whitespace
+VariableName
+Whitespace
+Punctuation
+Whitespace
+VariableName
+Whitespace
+KeywordControl
+Whitespace
+KeywordModifier
+Whitespace
+Type
+Punctuation
+Punctuation
+NewLine

--- a/test/cases/type-assertion-readonly-array.ts
+++ b/test/cases/type-assertion-readonly-array.ts
@@ -1,0 +1,1 @@
+const items = value as readonly DroppedItem[]


### PR DESCRIPTION
Recognize the element type in readonly array type assertions such as `value as readonly DroppedItem[]`. Adds a focused syntax-highlighting regression fixture.